### PR TITLE
Make it possible to run will_oops.in multiple times in row

### DIFF
--- a/src/will_oops.in
+++ b/src/will_oops.in
@@ -26,3 +26,6 @@ make
 
 echo "Loading the module ..."
 insmod will_oops.ko
+
+echo "Removing the module..."
+rmmod will_oops


### PR DESCRIPTION
Without this second run failed with:

```
# bash will_oops.in 
Building kernel module ...
make -C /lib/modules/3.10.0-229.el7.x86_64/build M=/tmp/will_oops.zVaLn3rVaN modules
make[1]: Entering directory `/usr/src/kernels/3.10.0-229.el7.x86_64'
  CC [M]  /tmp/will_oops.zVaLn3rVaN/will_oops.o
  Building modules, stage 2.
  MODPOST 1 modules
  CC      /tmp/will_oops.zVaLn3rVaN/will_oops.mod.o
  LD [M]  /tmp/will_oops.zVaLn3rVaN/will_oops.ko
make[1]: Leaving directory `/usr/src/kernels/3.10.0-229.el7.x86_64'
Loading the module ...
insmod: ERROR: could not insert module will_oops.ko: File exists
```

and did not produced the trace.