### PR TITLE
fix will_python_sigsegv for s390x

### DIFF
--- a/src/will_python_sigsegv
+++ b/src/will_python_sigsegv
@@ -1,4 +1,4 @@
 #!/usr/bin/env python2
 print 'Will segfault python.'
 import ctypes
-ctypes.string_at(0)
+ctypes.string_at(1)


### PR DESCRIPTION
for some reason ctypes.string_at(0) doesn't cause sigsegv on ia64 and s390x.
s390x: pass, no error
ia64: python: Objects/stringobject.c:117: PyString_FromString: Assertion `str != ((void *)0)' failed.
Aborted

With address 1 python crash with sigsegv on all these architectures (RHEL):
i686, x86_64, ia64, ppc64, ppc64_le, s390x, aarch64