### PR TITLE
configure: fix parsing of java version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,8 @@ AC_PATH_PROGS(JAR,jar,,[$javahome/bin])
 JARFLAGS=cvf
 AC_SUBST(JARFLAGS)
 
-JAVA_VER=(`"$JAVA" -version 2>&1 | awk 'BEGIN { FS="[[\".]]" } /^.*java version "(.*)\.(.*)\.(.*)"/ { print $2, $3, $4 }'`)
+JAVA_VER=(`"$JAVA" -version 2>&1 | awk 'BEGIN { FS="[[\".]]" } /^.*version "(.*)\.(.*)\.(.*)"/ { print $2, $3, $4 }'`)
+[echo "$JAVA"]
 [echo "Java version ${JAVA_VER[@]}"]
 [if test ${JAVA_VER[0]} -gt 1 -o ${JAVA_VER[1]} -gt 6; then]
     AM_CONDITIONAL(JAVA_SUPPORTS_SUPPRESSED, true)


### PR DESCRIPTION
$ java -version
openjdk version "1.8.0_171"
OpenJDK Runtime Environment (build 1.8.0_171-b10)
OpenJDK 64-Bit Server VM (build 25.171-b10, mixed mode)

"*java version" regexp didn't match anything.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>