### PR TITLE
spec: Recommend kernel-devel

### DIFF
--- a/will-crash.spec
+++ b/will-crash.spec
@@ -23,6 +23,7 @@ Requires:       javapackages-tools
 Requires:       perl-interpreter
 Requires:       python3
 Requires:       ruby
+Recommends:     kernel-devel
 
 %description
 The main purpose of this project is to provide sample


### PR DESCRIPTION
Without the kernel-devel package installed, will_oops fails with:
Kernel build tree not found
Please install the kernel-devel package

We might as well install it with will-crash.